### PR TITLE
Adjust bootstrap_flash to match bootstrap alerts

### DIFF
--- a/app/helpers/bootstrap_flash_helper.rb
+++ b/app/helpers/bootstrap_flash_helper.rb
@@ -4,6 +4,7 @@ module BootstrapFlashHelper
   def bootstrap_flash
     output = ''
     flash.each do |type, message|
+      next if message.blank?
       type = :success if type == :notice
       type = :error   if type == :alert
       next unless ALERT_TYPES.include?(type)

--- a/spec/helpers/bootstrap_flash_helper_spec.rb
+++ b/spec/helpers/bootstrap_flash_helper_spec.rb
@@ -33,5 +33,10 @@ describe BootstrapFlashHelper do
        bootstrap_flash.should == ""
      end
 
+     it "should return no message when the message is blank" do
+       stub!(:flash).and_return({:notice => ""})
+       bootstrap_flash.should == ""
+     end
+
    end
 end


### PR DESCRIPTION
This pull request implements some of the functionality in bootstrap-sass-rails. Specifically it addresses an issue that was being presented when using latest Devise for Rails 4. Devise expects only specific flash messages to be accessed, see https://github.com/plataformatec/devise#configuring-controllers
