### PR TITLE
Rails Form Helper for Bootstrap META tag

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bootstrap-sass-extras (0.0.1)
+    bootstrap-sass-extras (0.0.4)
       rails (>= 3.1.0)
 
 GEM
@@ -42,11 +42,10 @@ GEM
     i18n (0.6.1)
     journey (1.0.4)
     json (1.7.7)
-    mail (2.5.3)
-      i18n (>= 0.4.0)
+    mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
-    mime-types (1.21)
+    mime-types (1.25)
     multi_json (1.7.2)
     polyglot (0.3.3)
     rack (1.4.5)
@@ -93,7 +92,7 @@ GEM
     sqlite3 (1.3.7)
     thor (0.17.0)
     tilt (1.3.6)
-    treetop (1.4.12)
+    treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
     tzinfo (0.3.37)

--- a/README.md
+++ b/README.md
@@ -73,6 +73,20 @@ Notice the plural usage of the resource to generate bootstrap:themed.
 
 ## Using Helpers
 
+### Viewport Meta Helper
+Add the viewport meta helper `<%= viewport_meta_tag %>` to your layout
+(built-in with layout generator) to render the required meta tag for Bootstrap:
+
+    <meta content="width=device-width,initial-scale=1.0" name="viewport" />
+
+You can change the content value by passing a hash as an argument:
+
+    <%= viewport_meta_tag(:maximum_scale => "1.0") %>
+
+Renders:
+
+    <meta content="width=device-width,initial-scale=1.0,maximum-scale=1.0" name="viewport" />
+
 ### Flash helper
 Add flash helper `<%= bootstrap_flash %>` to your layout (built-in with layout generator)
 

--- a/app/helpers/bootstrap_viewport_meta_helper.rb
+++ b/app/helpers/bootstrap_viewport_meta_helper.rb
@@ -1,0 +1,27 @@
+module BootstrapViewportMetaHelper
+  #
+  # Creates the meta tag for Bootstrap with the specified parameters:
+  #
+  #     <%= viewport_meta_tag %>
+  #
+  # Renders:
+  #
+  #     <meta content="width=device-width,initial-scale=1.0" name="viewport" />
+  #
+  # You can change the content value by passing a hash as an argument:
+  #
+  #     <%= viewport_meta_tag(:maximum_scale => "1.0") %>
+  #
+  # Renders:
+  #
+  #     <meta content="width=device-width,initial-scale=1.0,maximum-scale=1.0" name="viewport" />
+  #
+  def viewport_meta_tag(*args)
+    options = {
+      width: "device-width",
+      initial_scale: "1.0" }.merge(args[0] || {})
+
+      content = options.collect {|key,value| "#{key.to_s.dasherize}=#{value}"}.join(",")
+      raw(tag(:meta, name: "viewport", content: content))
+  end
+end

--- a/lib/bootstrap-sass-extras/engine.rb
+++ b/lib/bootstrap-sass-extras/engine.rb
@@ -4,6 +4,7 @@ module BootstrapSassExtras
     initializer 'bootstrap-sass-extras.setup_helpers' do |app|
       app.config.to_prepare do
         ActionController::Base.send :helper, BootstrapFlashHelper
+        ActionController::Base.send :helper, BootstrapViewportMetaHelper
         ActionController::Base.send :helper, GlyphHelper
         ActionController::Base.send :helper, ModalHelper
         ActionController::Base.send :helper, TwitterBreadcrumbsHelper

--- a/lib/generators/bootstrap/layout/templates/layout.html.erb
+++ b/lib/generators/bootstrap/layout/templates/layout.html.erb
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <%%= viewport_meta_tag %>
     <title><%%= content_for?(:title) ? yield(:title) : "<%= app_name %>" %></title>
     <%%= csrf_meta_tags %>
 

--- a/lib/generators/bootstrap/layout/templates/layout.html.haml
+++ b/lib/generators/bootstrap/layout/templates/layout.html.haml
@@ -3,7 +3,7 @@
   %head
     %meta(charset="utf-8")
     %meta(http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1")
-    %meta(name="viewport" content="width=device-width, initial-scale=1.0")
+    = viewport_meta_tag
     %title= content_for?(:title) ? yield(:title) : "<%= app_name %>"
     = csrf_meta_tags
     / Le HTML5 shim, for IE6-8 support of HTML elements

--- a/lib/generators/bootstrap/layout/templates/layout.html.slim
+++ b/lib/generators/bootstrap/layout/templates/layout.html.slim
@@ -3,7 +3,7 @@ html lang="en"
   head
     meta charset="utf-8"
     meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1"
-    meta name="viewport" content="width=device-width, initial-scale=1.0"
+    = viewport_meta_tag
     title= content_for?(:title) ? yield(:title) : "<%= app_name %>"
     = csrf_meta_tags
 

--- a/spec/helpers/bootstrap_viewport_meta_helper_spec.rb
+++ b/spec/helpers/bootstrap_viewport_meta_helper_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe BootstrapViewportMetaHelper do
+  describe :viewport_meta_tag do
+    context "no arguments" do
+      it "should return the default viewport meta tag" do
+        viewport_meta_tag.should =="<meta content=\"width=device-width,initial-scale=1.0\" name=\"viewport\" />"
+      end
+    end
+
+    context "with arguments" do
+      it "should return the viewport meta tag with the specified options" do
+        viewport_meta_tag(initial_scale: "2.0").should =="<meta content=\"width=device-width,initial-scale=2.0\" name=\"viewport\" />"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Creates the meta tag for Bootstrap with the specified parameters:

```
<%= viewport_meta_tag %>
```

Renders:

```
<meta content="width=device-width,initial-scale=1.0" name="viewport" />
```

You can change the content value by passing a hash as an argument:

```
<%= viewport_meta_tag(:maximum_scale => "1.0") %>
```

Renders:

```
<meta content="width=device-width,initial-scale=1.0,maximum-scale=1.0" name="viewport" />
```
