### PR TITLE
New hash syntax

### DIFF
--- a/lib/generators/bootstrap/layout/templates/layout.html.erb
+++ b/lib/generators/bootstrap/layout/templates/layout.html.erb
@@ -13,27 +13,27 @@
       <script src="//cdnjs.cloudflare.com/ajax/libs/respond.js/1.3.0/respond.js" type="text/javascript"></script>
     <![endif]-->
 
-    <%%= stylesheet_link_tag "application", :media => "all" %>
+    <%%= stylesheet_link_tag "application", media: "all" %>
 
     <!-- For third-generation iPad with high-resolution Retina display: -->
     <!-- Size should be 144 x 144 pixels -->
-    <%%= favicon_link_tag 'apple-touch-icon-144x144-precomposed.png', :rel => 'apple-touch-icon-precomposed', :type => 'image/png', :sizes => '144x144' %>
+    <%%= favicon_link_tag 'apple-touch-icon-144x144-precomposed.png', rel: 'apple-touch-icon-precomposed', type: 'image/png', sizes: '144x144' %>
 
     <!-- For iPhone with high-resolution Retina display: -->
     <!-- Size should be 114 x 114 pixels -->
-    <%%= favicon_link_tag 'apple-touch-icon-114x114-precomposed.png', :rel => 'apple-touch-icon-precomposed', :type => 'image/png', :sizes => '114x114' %>
+    <%%= favicon_link_tag 'apple-touch-icon-114x114-precomposed.png', rel: 'apple-touch-icon-precomposed', type: 'image/png', sizes: '114x114' %>
 
     <!-- For first- and second-generation iPad: -->
     <!-- Size should be 72 x 72 pixels -->
-    <%%= favicon_link_tag 'apple-touch-icon-72x72-precomposed.png', :rel => 'apple-touch-icon-precomposed', :type => 'image/png', :sizes => '72x72' %>
+    <%%= favicon_link_tag 'apple-touch-icon-72x72-precomposed.png', rel: 'apple-touch-icon-precomposed', type: 'image/png', sizes: '72x72' %>
 
     <!-- For non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
     <!-- Size should be 57 x 57 pixels -->
-    <%%= favicon_link_tag 'apple-touch-icon-precomposed.png', :rel => 'apple-touch-icon-precomposed', :type => 'image/png' %>
+    <%%= favicon_link_tag 'apple-touch-icon-precomposed.png', rel: 'apple-touch-icon-precomposed', type: 'image/png' %>
 
     <!-- For all other devices -->
     <!-- Size should be 32 x 32 pixels -->
-    <%%= favicon_link_tag 'favicon.ico', :rel => 'shortcut icon' %>
+    <%%= favicon_link_tag 'favicon.ico', rel: 'shortcut icon' %>
     <%%= javascript_include_tag "application" %>
   </head>
   <body>

--- a/lib/generators/bootstrap/layout/templates/layout.html.haml
+++ b/lib/generators/bootstrap/layout/templates/layout.html.haml
@@ -10,12 +10,12 @@
     /[if lt IE 9]
       = javascript_include_tag "//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.6.1/html5shiv.js"
       = javascript_include_tag "//cdnjs.cloudflare.com/ajax/libs/respond.js/1.3.0/respond.js"
-    = stylesheet_link_tag "application", :media => "all"
-    = favicon_link_tag 'apple-touch-icon-144x144-precomposed.png', :rel => 'apple-touch-icon-precomposed', :type => 'image/png', :sizes => '144x144'
-    = favicon_link_tag 'apple-touch-icon-114x114-precomposed.png', :rel => 'apple-touch-icon-precomposed', :type => 'image/png', :sizes => '114x114'
-    = favicon_link_tag 'apple-touch-icon-72x72-precomposed.png', :rel => 'apple-touch-icon-precomposed', :type => 'image/png', :sizes => '72x72'
-    = favicon_link_tag 'apple-touch-icon-precomposed.png', :rel => 'apple-touch-icon-precomposed', :type => 'image/png'
-    = favicon_link_tag 'favicon.ico', :rel => 'shortcut icon'
+    = stylesheet_link_tag "application", media: "all"
+    = favicon_link_tag 'apple-touch-icon-144x144-precomposed.png', rel: 'apple-touch-icon-precomposed', type: 'image/png', sizes: '144x144'
+    = favicon_link_tag 'apple-touch-icon-114x114-precomposed.png', rel: 'apple-touch-icon-precomposed', type: 'image/png', sizes: '114x114'
+    = favicon_link_tag 'apple-touch-icon-72x72-precomposed.png', rel: 'apple-touch-icon-precomposed', type: 'image/png', sizes: '72x72'
+    = favicon_link_tag 'apple-touch-icon-precomposed.png', rel: 'apple-touch-icon-precomposed', type: 'image/png'
+    = favicon_link_tag 'favicon.ico', rel: 'shortcut icon'
     = javascript_include_tag "application"
 
   %body

--- a/lib/generators/bootstrap/layout/templates/layout.html.slim
+++ b/lib/generators/bootstrap/layout/templates/layout.html.slim
@@ -11,12 +11,12 @@ html lang="en"
     /[if lt IE 9]
       = javascript_include_tag "//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.6.1/html5shiv.js"
       = javascript_include_tag "//cdnjs.cloudflare.com/ajax/libs/respond.js/1.3.0/respond.js"
-    = stylesheet_link_tag "application", :media => "all"
-    = favicon_link_tag 'apple-touch-icon-144x144-precomposed.png', :rel => 'apple-touch-icon-precomposed', :type => 'image/png', :sizes => '144x144'
-    = favicon_link_tag 'apple-touch-icon-114x114-precomposed.png', :rel => 'apple-touch-icon-precomposed', :type => 'image/png', :sizes => '114x114'
-    = favicon_link_tag 'apple-touch-icon-72x72-precomposed.png', :rel => 'apple-touch-icon-precomposed', :type => 'image/png', :sizes => '72x72'
-    = favicon_link_tag 'apple-touch-icon-precomposed.png', :rel => 'apple-touch-icon-precomposed', :type => 'image/png'
-    = favicon_link_tag 'favicon.ico', :rel => 'shortcut icon'
+    = stylesheet_link_tag "application", media: "all"
+    = favicon_link_tag 'apple-touch-icon-144x144-precomposed.png', rel: 'apple-touch-icon-precomposed', type: 'image/png', sizes: '144x144'
+    = favicon_link_tag 'apple-touch-icon-114x114-precomposed.png', rel: 'apple-touch-icon-precomposed', type: 'image/png', sizes: '114x114'
+    = favicon_link_tag 'apple-touch-icon-72x72-precomposed.png', rel: 'apple-touch-icon-precomposed', type: 'image/png', sizes: '72x72'
+    = favicon_link_tag 'apple-touch-icon-precomposed.png', rel: 'apple-touch-icon-precomposed', type: 'image/png'
+    = favicon_link_tag 'favicon.ico', rel: 'shortcut icon'
     = javascript_include_tag "application"
 
   body

--- a/lib/generators/bootstrap/partial/templates/_login.html.erb
+++ b/lib/generators/bootstrap/partial/templates/_login.html.erb
@@ -1,14 +1,14 @@
 <h2>Sign in</h2>
 
-<%= form_for(resource, :as => resource_name, :url => session_path(resource_name), :html => { :class => 'form-horizontal' }) do |f| %>
+<%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: 'form-horizontal' }) do |f| %>
   <div class="control-group">
-    <%= f.label :email, :class => 'control-label' %>
+    <%= f.label :email, class: 'control-label' %>
     <div class="controls">
       <%= f.email_field :email %>
     </div>
   </div>
   <div class="control-group">
-      <%= f.label :password, :class => 'control-label' %>
+      <%= f.label :password, class: 'control-label' %>
       <div class="controls">
         <%= f.password_field :password %>
       </div>
@@ -16,14 +16,14 @@
 
   <% if devise_mapping.rememberable? -%>
     <div class='control-group' >
-      <%= f.label :remember_me, :class => 'control-label' %>
+      <%= f.label :remember_me, class: 'control-label' %>
       <%= f.check_box :remember_me %> 
     </div>
   <% end -%>
 
   <div class="form-actions">
-    <%= f.submit "Sign in", :class => 'btn' %>
+    <%= f.submit "Sign in", class: 'btn' %>
   </div>
 <% end %>
 
-<%= render :partial => "devise/shared/links" %>
+<%= render partial: "devise/shared/links" %>

--- a/lib/generators/bootstrap/themed/templates/_form.html.erb
+++ b/lib/generators/bootstrap/themed/templates/_form.html.erb
@@ -1,18 +1,18 @@
-<%%= form_for @<%= resource_name %>, :html => { :class => 'form-horizontal' } do |f| %>
+<%%= form_for @<%= resource_name %>, html: { class: 'form-horizontal' } do |f| %>
   <%- columns.each do |column| -%>
   <div class="form-group">
-    <%%= f.label :<%= column.name %>, :class => 'control-label col-md-2' %>
+    <%%= f.label :<%= column.name %>, class: 'control-label col-md-2' %>
     <div class="col-md-10">
-      <%%= f.<%= column.field_type %> :<%= column.name %>, :class => '<%= column.field_type %> form-control' %>
+      <%%= f.<%= column.field_type %> :<%= column.name %>, class: '<%= column.field_type %> form-control' %>
     </div>
   </div>
   <%- end -%>
 
   <div class="form-group">
     <div class='col-md-offset-2 col-md-10'>
-      <%%= f.submit nil, :class => 'btn btn-primary' %>
-      <%%= link_to t('.cancel', :default => t("helpers.links.cancel")),
-                  <%= controller_routing_path %>_path, :class => 'btn btn-default' %>
+      <%%= f.submit nil, class: 'btn btn-primary' %>
+      <%%= link_to t('.cancel', default: t("helpers.links.cancel")),
+                  <%= controller_routing_path %>_path, class: 'btn btn-default' %>
     </div>
   </div>
 <%% end %>

--- a/lib/generators/bootstrap/themed/templates/_form.html.haml
+++ b/lib/generators/bootstrap/themed/templates/_form.html.haml
@@ -1,11 +1,11 @@
-= form_for @<%= resource_name %>, :html => { :class => 'form-horizontal' } do |f|
+= form_for @<%= resource_name %>, html: { class: 'form-horizontal' } do |f|
   <%- columns.each do |column| -%>
   .form-group
-    = f.label :<%= column.name %>, :class => 'control-label col-md-2'
+    = f.label :<%= column.name %>, class: 'control-label col-md-2'
     .col-md-10
-      = f.<%= column.field_type %> :<%= column.name %>, :class => '<%= column.field_type %> form-control'
+      = f.<%= column.field_type %> :<%= column.name %>, class: '<%= column.field_type %> form-control'
   <%- end -%>
   .form-group
     .col-md-offset-2.col-md-10
-      = f.submit nil, :class => 'btn btn-primary'
-      = link_to t('.cancel', :default => t("helpers.links.cancel")), <%= controller_routing_path %>_path, :class => 'btn btn-default'
+      = f.submit nil, class: 'btn btn-primary'
+      = link_to t('.cancel', default: t("helpers.links.cancel")), <%= controller_routing_path %>_path, class: 'btn btn-default'

--- a/lib/generators/bootstrap/themed/templates/_form.html.slim
+++ b/lib/generators/bootstrap/themed/templates/_form.html.slim
@@ -1,11 +1,11 @@
-= form_for @<%= resource_name %>, :html => { :class => "form-horizontal" } do |f|
+= form_for @<%= resource_name %>, html: { class: "form-horizontal" } do |f|
   <%- columns.each do |column| -%>
   .form-group
-    = f.label :<%= column.name %>, :class => 'control-label col-md-2'
+    = f.label :<%= column.name %>, class: 'control-label col-md-2'
     .col-md-10
-      = f.<%= column.field_type %> :<%= column.name %>, :class => '<%= column.field_type %> form-control'
+      = f.<%= column.field_type %> :<%= column.name %>, class: '<%= column.field_type %> form-control'
   <%- end -%>
   .form-group
     .col-md-offset-2.col-md-10
-      = f.submit nil, :class => 'btn btn-primary'
-      = link_to t('.cancel', :default => t("helpers.links.cancel")), <%= controller_routing_path %>_path, :class => 'btn btn-default'
+      = f.submit nil, class: 'btn btn-primary'
+      = link_to t('.cancel', default: t("helpers.links.cancel")), <%= controller_routing_path %>_path, class: 'btn btn-default'

--- a/lib/generators/bootstrap/themed/templates/edit.html.erb
+++ b/lib/generators/bootstrap/themed/templates/edit.html.erb
@@ -1,5 +1,5 @@
 <%%- model_class = <%= resource_name.classify %> -%>
 <div class="page-header">
-  <h1><%%=t '.title', :default => [:'helpers.titles.edit', 'Edit %{model}'], :model => model_class.model_name.human.titleize %></h1>
+  <h1><%%=t '.title', default: [:'helpers.titles.edit', 'Edit %{model}'], model: model_class.model_name.human.titleize %></h1>
 </div>
-<%%= render :partial => 'form' %>
+<%%= render partial: 'form' %>

--- a/lib/generators/bootstrap/themed/templates/edit.html.haml
+++ b/lib/generators/bootstrap/themed/templates/edit.html.haml
@@ -1,4 +1,4 @@
 - model_class = <%= resource_name.classify %>
 .page-header
-  %h1=t '.title', :default => [:'helpers.titles.edit', 'Edit %{model}'], :model => model_class.model_name.human.titleize
-= render :partial => "form"
+  %h1=t '.title', default: [:'helpers.titles.edit', 'Edit %{model}'], model: model_class.model_name.human.titleize
+= render partial: "form"

--- a/lib/generators/bootstrap/themed/templates/edit.html.slim
+++ b/lib/generators/bootstrap/themed/templates/edit.html.slim
@@ -1,4 +1,4 @@
 - model_class = <%= resource_name.classify %>
 div class="page-header"
-  h1=t '.title', :default => [:'helpers.titles.edit', 'Edit %{model}'], :model => model_class.model_name.human.titleize
-= render :partial => "form"
+  h1=t '.title', default: [:'helpers.titles.edit', 'Edit %{model}'], model: model_class.model_name.human.titleize
+= render partial: "form"

--- a/lib/generators/bootstrap/themed/templates/index.html.erb
+++ b/lib/generators/bootstrap/themed/templates/index.html.erb
@@ -1,6 +1,6 @@
 <%%- model_class = <%= resource_name.classify %> -%>
 <div class="page-header">
-  <h1><%%=t '.title', :default => model_class.model_name.human.pluralize.titleize %></h1>
+  <h1><%%=t '.title', default: model_class.model_name.human.pluralize.titleize %></h1>
 </div>
 <table class="table table-striped">
   <thead>
@@ -10,7 +10,7 @@
       <th><%%= model_class.human_attribute_name(:<%= column.name %>) %></th>
       <%- end -%>
       <th><%%= model_class.human_attribute_name(:created_at) %></th>
-      <th><%%=t '.actions', :default => t("helpers.actions") %></th>
+      <th><%%=t '.actions', default: t("helpers.actions") %></th>
     </tr>
   </thead>
   <tbody>
@@ -22,13 +22,13 @@
         <%- end -%>
         <td><%%=l <%= resource_name %>.created_at, format: :long %></td>
         <td>
-          <%%= link_to <%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-xs', :title => "#{ t('.show', :default => t('helpers.links.show')) }" do %>
+          <%%= link_to <%= singular_controller_routing_path %>_path(<%= resource_name %>), class: 'btn btn-xs', title: "#{ t('.show', default: t('helpers.links.show')) }" do %>
             <%%= glyph 'info-sign' %>
           <%%- end -%>
-          <%%= link_to edit_<%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-xs', :title => "#{ t('.edit', :default => t('helpers.links.edit')) }" do %>
+          <%%= link_to edit_<%= singular_controller_routing_path %>_path(<%= resource_name %>), class: 'btn btn-xs', title: "#{ t('.edit', default: t('helpers.links.edit')) }" do %>
             <%%= glyph 'pencil' %>
           <%%- end -%>
-          <%%= link_to <%= singular_controller_routing_path %>_path(<%= resource_name %>), :method => :delete, :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) }, :class => 'btn btn-xs', :title => "#{ t('.destroy', :default => t('helpers.links.destroy')) }" do %>
+          <%%= link_to <%= singular_controller_routing_path %>_path(<%= resource_name %>), method: :delete, data: { confirm: t('.confirm', default: t("helpers.links.confirm", default: 'Are you sure?')) }, class: 'btn btn-xs', title: "#{ t('.destroy', default: t('helpers.links.destroy')) }" do %>
             <%%= glyph 'remove' %>
           <%%- end -%>
         </td>
@@ -37,6 +37,6 @@
   </tbody>
 </table>
 
-<%%= link_to t('.new', :default => t("helpers.links.new")),
+<%%= link_to t('.new', default: t("helpers.links.new")),
             new_<%= singular_controller_routing_path %>_path,
-            :class => 'btn btn-primary' %>
+            class: 'btn btn-primary' %>

--- a/lib/generators/bootstrap/themed/templates/index.html.haml
+++ b/lib/generators/bootstrap/themed/templates/index.html.haml
@@ -1,6 +1,6 @@
 - model_class = <%= resource_name.classify %>
 .page-header
-  %h1=t '.title', :default => model_class.model_name.human.pluralize.titleize
+  %h1=t '.title', default: model_class.model_name.human.pluralize.titleize
 %table.table.table-striped
   %thead
     %tr
@@ -9,7 +9,7 @@
       %th= model_class.human_attribute_name(:<%= column.name %>)
       <%- end -%>
       %th= model_class.human_attribute_name(:created_at)
-      %th=t '.actions', :default => t("helpers.actions")
+      %th=t '.actions', default: t("helpers.actions")
   %tbody
     - @<%= plural_resource_name %>.each do |<%= resource_name %>|
       %tr
@@ -19,11 +19,11 @@
         <%- end -%>
         %td=l <%= resource_name %>.created_at, format: :long
         %td
-          = link_to <%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-xs', :title => "#{ t('.show', :default => t('helpers.links.show')) }" do
+          = link_to <%= singular_controller_routing_path %>_path(<%= resource_name %>), class: 'btn btn-xs', title: "#{ t('.show', default: t('helpers.links.show')) }" do
             = glyph 'info-sign'
-          = link_to edit_<%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-xs', :title => "#{ t('.edit', :default => t('helpers.links.edit')) }" do
+          = link_to edit_<%= singular_controller_routing_path %>_path(<%= resource_name %>), class: 'btn btn-xs', title: "#{ t('.edit', default: t('helpers.links.edit')) }" do
             = glyph 'pencil'
-          = link_to <%= singular_controller_routing_path %>_path(<%= resource_name %>), :method => :delete, :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) }, :class => 'btn btn-xs', :title => "#{ t('.destroy', :default => t('helpers.links.destroy')) }"  do
+          = link_to <%= singular_controller_routing_path %>_path(<%= resource_name %>), method: :delete, data: { confirm: t('.confirm', default: t("helpers.links.confirm", default: 'Are you sure?')) }, class: 'btn btn-xs', title: "#{ t('.destroy', default: t('helpers.links.destroy')) }" do
             = glyph 'remove'
 
-= link_to t('.new', :default => t("helpers.links.new")), new_<%= singular_controller_routing_path %>_path, :class => 'btn btn-primary'
+= link_to t('.new', default: t("helpers.links.new")), new_<%= singular_controller_routing_path %>_path, class: 'btn btn-primary'

--- a/lib/generators/bootstrap/themed/templates/index.html.slim
+++ b/lib/generators/bootstrap/themed/templates/index.html.slim
@@ -1,6 +1,6 @@
 - model_class = <%= resource_name.classify %>
 .page-header
-  h1=t '.title', :default => model_class.model_name.human.pluralize.titleize
+  h1=t '.title', default: model_class.model_name.human.pluralize.titleize
 table.table.table-striped
   thead
     tr
@@ -9,7 +9,7 @@ table.table.table-striped
       th= model_class.human_attribute_name(:<%= column.name %>)
       <%- end -%>
       th= model_class.human_attribute_name(:created_at)
-      th=t '.actions', :default => t("helpers.actions")
+      th=t '.actions', default: t("helpers.actions")
   tbody
     - @<%= plural_resource_name %>.each do |<%= resource_name %>|
       tr
@@ -19,11 +19,11 @@ table.table.table-striped
         <%- end -%>
         td=l <%= resource_name %>.created_at, format: :long
         td
-          = link_to <%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-xs', :title => "#{ t('.show', :default => t('helpers.links.show')) }" do
+          = link_to <%= singular_controller_routing_path %>_path(<%= resource_name %>), class: 'btn btn-xs', title: "#{ t('.show', default: t('helpers.links.show')) }" do
             = glyph 'info-sign'
-          = link_to edit_<%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-xs', :title => "#{ t('.edit', :default => t('helpers.links.edit')) }" do
+          = link_to edit_<%= singular_controller_routing_path %>_path(<%= resource_name %>), class: 'btn btn-xs', title: "#{ t('.edit', default: t('helpers.links.edit')) }" do
             = glyph 'pencil'
-          = link_to <%= singular_controller_routing_path %>_path(<%= resource_name %>), :method => :delete, :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) }, :class => 'btn btn-xs', :title => "#{ t('.destroy', :default => t('helpers.links.destroy')) }"  do
+          = link_to <%= singular_controller_routing_path %>_path(<%= resource_name %>), method: :delete, data: { confirm: t('.confirm', default: t("helpers.links.confirm", default: 'Are you sure?')) }, class: 'btn btn-xs', title: "#{ t('.destroy', default: t('helpers.links.destroy')) }" do
             = glyph 'remove'
 
-= link_to t('.new', :default => t("helpers.links.new")), new_<%= singular_controller_routing_path %>_path, :class => 'btn btn-primary'
+= link_to t('.new', default: t("helpers.links.new")), new_<%= singular_controller_routing_path %>_path, class: 'btn btn-primary'

--- a/lib/generators/bootstrap/themed/templates/new.html.erb
+++ b/lib/generators/bootstrap/themed/templates/new.html.erb
@@ -1,5 +1,5 @@
 <%%- model_class = <%= resource_name.classify %> -%>
 <div class="page-header">
-  <h1><%%=t '.title', :default => [:'helpers.titles.new', 'New %{model}'], :model => model_class.model_name.human.titleize %></h1>
+  <h1><%%=t '.title', default: [:'helpers.titles.new', 'New %{model}'], model: model_class.model_name.human.titleize %></h1>
 </div>
-<%%= render :partial => 'form' %>
+<%%= render partial: 'form' %>

--- a/lib/generators/bootstrap/themed/templates/new.html.haml
+++ b/lib/generators/bootstrap/themed/templates/new.html.haml
@@ -1,4 +1,4 @@
 - model_class = <%= resource_name.classify %>
 .page-header
-  %h1=t '.title', :default => [:'helpers.titles.new', 'New %{model}'], :model => model_class.model_name.human.titleize
-= render :partial => "form"
+  %h1=t '.title', default: [:'helpers.titles.new', 'New %{model}'], model: model_class.model_name.human.titleize
+= render partial: "form"

--- a/lib/generators/bootstrap/themed/templates/new.html.slim
+++ b/lib/generators/bootstrap/themed/templates/new.html.slim
@@ -1,4 +1,4 @@
 - model_class = <%= resource_name.classify %>
 .page-header
-  h1=t '.title', :default => [:'helpers.titles.new', 'New %{model}'], :model => model_class.model_name.human.titleize
-= render :partial => "form"
+  h1=t '.title', default: [:'helpers.titles.new', 'New %{model}'], model: model_class.model_name.human.titleize
+= render partial: "form"

--- a/lib/generators/bootstrap/themed/templates/show.html.erb
+++ b/lib/generators/bootstrap/themed/templates/show.html.erb
@@ -1,6 +1,6 @@
 <%%- model_class = <%= resource_name.classify %> -%>
 <div class="page-header">
-  <h1><%%=t '.title', :default => model_class.model_name.human.titleize %></h1>
+  <h1><%%=t '.title', default: model_class.model_name.human.titleize %></h1>
 </div>
 
 <div class="fieldset">
@@ -13,13 +13,13 @@
 </div>
 
 <div class="form-group">
-  <%%= link_to t('.back', :default => t("helpers.links.back")),
-              <%= controller_routing_path %>_path, :class => 'btn btn-default'  %>
-  <%%= link_to t('.edit', :default => t("helpers.links.edit")),
-              edit_<%= singular_controller_routing_path %>_path(@<%= resource_name %>), :class => 'btn btn-default' %>
-  <%%= link_to t('.destroy', :default => t("helpers.links.destroy")),
+  <%%= link_to t('.back', default: t("helpers.links.back")),
+              <%= controller_routing_path %>_path, class: 'btn btn-default'  %>
+  <%%= link_to t('.edit', default: t("helpers.links.edit")),
+              edit_<%= singular_controller_routing_path %>_path(@<%= resource_name %>), class: 'btn btn-default' %>
+  <%%= link_to t('.destroy', default: t("helpers.links.destroy")),
               <%= singular_controller_routing_path %>_path(@<%= resource_name %>),
-              :method => 'delete',
-              :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) },
-              :class => 'btn btn-danger' %>
+              method: 'delete',
+              data: { confirm: t('.confirm', default: t("helpers.links.confirm", default: 'Are you sure?')) },
+              class: 'btn btn-danger' %>
 </div>

--- a/lib/generators/bootstrap/themed/templates/show.html.haml
+++ b/lib/generators/bootstrap/themed/templates/show.html.haml
@@ -1,6 +1,6 @@
 - model_class = <%= resource_name.classify %>
 div class="page-header"
-  h1=t '.title', :default => model_class.model_name.human.titleize
+  h1=t '.title', default: model_class.model_name.human.titleize
 
 .fieldset
   dl
@@ -11,6 +11,6 @@ div class="page-header"
     <%- end -%>
 
 .form-group
-  = link_to t('.back', :default => t("helpers.links.back")), <%= controller_routing_path %>_path, :class => 'btn btn-default'
-  = link_to t('.edit', :default => t("helpers.links.edit")), edit_<%= singular_controller_routing_path %>_path(@<%= resource_name %>), :class => 'btn btn-default'
-  = link_to t('.destroy', :default => t("helpers.links.destroy")), <%= singular_controller_routing_path %>_path(@<%= resource_name %>), :method => "delete", :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) }, :class => 'btn btn-danger'
+  = link_to t('.back', default: t("helpers.links.back")), <%= controller_routing_path %>_path, class: 'btn btn-default'
+  = link_to t('.edit', default: t("helpers.links.edit")), edit_<%= singular_controller_routing_path %>_path(@<%= resource_name %>), class: 'btn btn-default'
+  = link_to t('.destroy', default: t("helpers.links.destroy")), <%= singular_controller_routing_path %>_path(@<%= resource_name %>), method: "delete", data: { confirm: t('.confirm', default: t("helpers.links.confirm", default: 'Are you sure?')) }, class: 'btn btn-danger'

--- a/lib/generators/bootstrap/themed/templates/show.html.slim
+++ b/lib/generators/bootstrap/themed/templates/show.html.slim
@@ -1,6 +1,6 @@
 - model_class = <%= resource_name.classify %>
 div class="page-header"
-  h1=t '.title', :default => model_class.model_name.human.titleize
+  h1=t '.title', default: model_class.model_name.human.titleize
 
 .fieldset
   dl
@@ -11,8 +11,8 @@ div class="page-header"
     <%- end -%>
 
 .form-group
-  = link_to t('.back', :default => t("helpers.links.back")), <%= controller_routing_path %>_path, :class => 'btn btn-default'
+  = link_to t('.back', default: t("helpers.links.back")), <%= controller_routing_path %>_path, class: 'btn btn-default'
   '
-  = link_to t('.edit', :default => t("helpers.links.edit")), edit_<%= singular_controller_routing_path %>_path(@<%= resource_name %>), :class => 'btn btn-default'
+  = link_to t('.edit', default: t("helpers.links.edit")), edit_<%= singular_controller_routing_path %>_path(@<%= resource_name %>), class: 'btn btn-default'
   '
-  = link_to t('.destroy', :default => t("helpers.links.destroy")), <%= singular_controller_routing_path %>_path(@<%= resource_name %>), :method => "delete", :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) }, :class => 'btn btn-danger'
+  = link_to t('.destroy', default: t("helpers.links.destroy")), <%= singular_controller_routing_path %>_path(@<%= resource_name %>), method: "delete", data: { confirm: t('.confirm', default: t("helpers.links.confirm", default: 'Are you sure?')) }, class: 'btn btn-danger'

--- a/lib/generators/bootstrap/themed/templates/simple_form/_form.html.erb
+++ b/lib/generators/bootstrap/themed/templates/simple_form/_form.html.erb
@@ -1,15 +1,15 @@
-<%%= simple_form_for @<%= resource_name %>, :html => { :class => 'form-horizontal' }, wrapper: :horizontal_form, wrapper_mappings: { check_boxes: :horizontal_radio_and_checkboxes, radio_buttons: :horizontal_radio_and_checkboxes, file: :horizontal_file_input, boolean: :horizontal_boolean } do |f| %>
+<%%= simple_form_for @<%= resource_name %>, html: { class: 'form-horizontal' }, wrapper: :horizontal_form, wrapper_mappings: { check_boxes: :horizontal_radio_and_checkboxes, radio_buttons: :horizontal_radio_and_checkboxes, file: :horizontal_file_input, boolean: :horizontal_boolean } do |f| %>
   <%- columns.each do |column| -%>
     <%%= f.input :<%= column.name %> %>
   <%- end -%>
   <%- if ::SimpleForm::FormBuilder.instance_methods.include?(:wrapped_button) -%>
-    <%%= f.button :wrapped, :cancel => <%= controller_routing_path %>_path %>
+    <%%= f.button :wrapped, cancel: <%= controller_routing_path %>_path %>
   <%- else -%>
   <div class="form-group">
     <div class='col-sm-offset-3 col-sm-9'>
-      <%%= f.button :submit, :class => 'btn-primary' %>
-      <%%= link_to t('.cancel', :default => t("helpers.links.cancel")),
-                  <%= controller_routing_path %>_path, :class => 'btn btn-default' %>
+      <%%= f.button :submit, class: 'btn-primary' %>
+      <%%= link_to t('.cancel', default: t("helpers.links.cancel")),
+                  <%= controller_routing_path %>_path, class: 'btn btn-default' %>
     </div>
   </div>
   <%- end -%>

--- a/lib/generators/bootstrap/themed/templates/simple_form/_form.html.haml
+++ b/lib/generators/bootstrap/themed/templates/simple_form/_form.html.haml
@@ -1,12 +1,12 @@
-= simple_form_for @<%= resource_name %>, :html => { :class => 'form-horizontal' }, wrapper: :horizontal_form, wrapper_mappings: { check_boxes: :horizontal_radio_and_checkboxes, radio_buttons: :horizontal_radio_and_checkboxes, file: :horizontal_file_input, boolean: :horizontal_boolean } do |f|
+= simple_form_for @<%= resource_name %>, html: { class: 'form-horizontal' }, wrapper: :horizontal_form, wrapper_mappings: { check_boxes: :horizontal_radio_and_checkboxes, radio_buttons: :horizontal_radio_and_checkboxes, file: :horizontal_file_input, boolean: :horizontal_boolean } do |f|
 <%- columns.each do |column| -%>
   = f.input :<%= column.name %>
 <%- end -%>
 <%- if ::SimpleForm::FormBuilder.instance_methods.include?(:wrapped_button) -%>
-  = f.button :wrapped, :cancel => <%= controller_routing_path %>_path
+  = f.button :wrapped, cancel: <%= controller_routing_path %>_path
 <%- else -%>
   .form-group
     .col-sm-offset-3.col-sm-9
-      = f.submit nil, :class => 'btn btn-primary'
-      = link_to t('.cancel', :default => t("helpers.links.cancel")), <%= controller_routing_path %>_path, :class => 'btn btn-default'
+      = f.submit nil, class: 'btn btn-primary'
+      = link_to t('.cancel', default: t("helpers.links.cancel")), <%= controller_routing_path %>_path, class: 'btn btn-default'
 <%- end -%>

--- a/lib/generators/bootstrap/themed/templates/simple_form/_form.html.slim
+++ b/lib/generators/bootstrap/themed/templates/simple_form/_form.html.slim
@@ -1,12 +1,12 @@
-= simple_form_for @<%= resource_name %>, :html => { :class => "form-horizontal" }, wrapper: :horizontal_form, wrapper_mappings: { check_boxes: :horizontal_radio_and_checkboxes, radio_buttons: :horizontal_radio_and_checkboxes, file: :horizontal_file_input, boolean: :horizontal_boolean } do |f|
+= simple_form_for @<%= resource_name %>, html: { class: "form-horizontal" }, wrapper: :horizontal_form, wrapper_mappings: { check_boxes: :horizontal_radio_and_checkboxes, radio_buttons: :horizontal_radio_and_checkboxes, file: :horizontal_file_input, boolean: :horizontal_boolean } do |f|
 <%- columns.each do |column| -%>
   = f.input :<%= column.name %>
 <%- end -%>
 <%- if ::SimpleForm::FormBuilder.instance_methods.include?(:wrapped_button) -%>
-  = f.button :wrapped, :cancel => <%= controller_routing_path %>_path
+  = f.button :wrapped, cancel: <%= controller_routing_path %>_path
 <%- else -%>
   .form-group
     .col-sm-offset-3.col-sm-9
-      = f.submit nil, :class => 'btn btn-primary'
-      = link_to t('.cancel', :default => t("helpers.links.cancel")), <%= controller_routing_path %>_path, :class => 'btn btn-default'
+      = f.submit nil, class: 'btn btn-primary'
+      = link_to t('.cancel', default: t("helpers.links.cancel")), <%= controller_routing_path %>_path, class: 'btn btn-default'
 <%- end -%>


### PR DESCRIPTION
I always search and replace the hash syntax from ':symbol =>' to 'symbol:' when using the generators. Just looks cleaner ;)

Thanks for an awesome gem!