### PR TITLE
Implement a pills/tabs view helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,32 @@ clear_breadcrumbs
 # => nil
 ```
 
+### Nav Helper
+
+To render the Bootstrap example:
+
+```html
+<ul class="nav nav-tabs">
+  <li role="presentation" class="active"><a href="/">Home</a></li>
+  <li role="presentation"><a href="/profile">Profile</a></li>
+  <li role="presentation"><a href="/messages">Messages</a></li>
+</ul>
+```
+
+In your views:
+
+```erb
+<%= tabs do %>
+  <%= nav_to('Home', root_path) %>
+  <%= nav_to(profile_path) do %>
+    Profile
+  <% end %>
+  <%= nav_to('Messages', controller: users, action: :messages) %>
+<% end %>
+```
+
+The `nav_to` helper accepts the same methods that the `link_to` helper accepts.
+
 ### Glyph Helper
 
 ```erb

--- a/README.md
+++ b/README.md
@@ -209,7 +209,12 @@ In your views:
 <% end %>
 ```
 
-The `nav_to` helper accepts the same methods that the `link_to` helper accepts.
+The `tabs` helper declares that a tab component is being used. Alternatively, the `pills` helper can
+be used in the same manner. Other classes can be specified in the `class` hash argument, the `nav`
+class need not be specified.
+
+The `nav_to` helper accepts the same methods that the `link_to` helper accepts, but also 
+automatically applies the `active` class to the active link.
 
 ### Glyph Helper
 

--- a/app/helpers/nav_helper.rb
+++ b/app/helpers/nav_helper.rb
@@ -1,6 +1,23 @@
 module NavHelper
-  def tabs(options = {}, &proc)
-    content_tag(:ul, class: 'nav nav-tabs'.freeze, &proc)
+  NAV_CLASS = 'nav'.freeze
+  NAV_TABS_CLASS = 'nav-tabs'.freeze
+  NAV_PILLS_CLASS = 'nav-pills'.freeze
+  NAV_CLASSES = [NAV_TABS_CLASS, NAV_PILLS_CLASS]
+
+  def nav(options = {}, type = NAV_TABS_CLASS, &block)
+    options, type = {}, options unless options.is_a?(Hash)
+    options[:class] ||= []
+    options[:class] = [*options[:class]]
+    options[:class].unshift(NAV_CLASS) unless options[:class].include?(NAV_CLASS)
+    options[:class] << type unless NAV_CLASSES.any? { |c| options[:class].include?(c) }
+
+    content_or_options_with_block = options if block_given?
+    content_tag(:ul, content_or_options_with_block, options, &block)
+  end
+  alias_method(:tabs, :nav)
+
+  def pills(*args, &block)
+    nav(*args, NAV_PILLS_CLASS, &block)
   end
 
   def nav_to(name = nil, options = nil, html_options = nil, &block)

--- a/app/helpers/nav_helper.rb
+++ b/app/helpers/nav_helper.rb
@@ -1,0 +1,16 @@
+module NavHelper
+  def tabs(options = {}, &proc)
+    content_tag(:ul, class: 'nav nav-tabs'.freeze, &proc)
+  end
+
+  def nav_to(name = nil, options = nil, html_options = nil, &block)
+    url_options = block_given? ? name : options
+    url_options ||= {}
+
+    tab_class = current_page?(url_options) ? 'active' : nil
+
+    content_tag(:li, role: 'presentation', class: tab_class) do
+      link_to(name, options, html_options, &block)
+    end
+  end
+end

--- a/lib/bootstrap-sass-extras/engine.rb
+++ b/lib/bootstrap-sass-extras/engine.rb
@@ -8,6 +8,7 @@ module BootstrapSassExtras
         ActionController::Base.send :helper, GlyphHelper
         ActionController::Base.send :helper, BadgeHelper
         ActionController::Base.send :helper, ModalHelper
+        ActionController::Base.send :helper, NavHelper
         ActionController::Base.send :helper, TwitterBreadcrumbsHelper
         ActionController::Base.send :helper, UrlHelper
         ActionController::Base.send :include, BootstrapSassExtras::BreadCrumbs

--- a/spec/helpers/nav_helper_spec.rb
+++ b/spec/helpers/nav_helper_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe NavHelper do
+  describe "#tabs" do
+    before do
+      def self.current_page?(path)
+        path == '/'
+      end
+    end
+
+    let(:html) {
+      <<-TABS.strip_heredoc
+          <ul class="nav nav-tabs">
+            <li class="active" role="presentation"><a href="/">Name</a></li>
+            <li role="presentation"><a href="/profile">Profile</a></li>
+          </ul>
+      TABS
+    }
+
+    it "generates the correct link" do
+      expect (tabs do
+        concat "\n  "
+        concat (nav_to 'Name', '/')
+        concat "\n  "
+        concat (nav_to '/profile' do
+          'Profile'
+        end)
+        concat "\n"
+      end + "\n").should == html
+    end
+  end
+end

--- a/spec/helpers/nav_helper_spec.rb
+++ b/spec/helpers/nav_helper_spec.rb
@@ -18,7 +18,7 @@ describe NavHelper do
     }
 
     it "generates the correct link" do
-      expect (tabs do
+      (nav do
         concat "\n  "
         concat (nav_to 'Name', '/')
         concat "\n  "
@@ -27,6 +27,30 @@ describe NavHelper do
         end)
         concat "\n"
       end + "\n").should == html
+    end
+
+    context "when a type of navigation is specified" do
+      let(:html) { '<ul class="nav nav-pills"></ul>' }
+
+      it "generates the correct link" do
+        (nav class: 'nav-pills').should == html
+      end
+    end
+
+    context "when the navigation type helper is used" do
+      let(:html) { '<ul class="nav nav-tabs"></ul>' }
+
+      it "generates the correct link" do
+        (tabs).should == html
+      end
+    end
+
+    context "when a stacked nav is used" do
+      let(:html) { '<ul class="nav nav-stacked nav-pills"></ul>' }
+
+      it "generates the correct link" do
+        (pills class: 'nav-stacked').should == html
+      end
     end
   end
 end


### PR DESCRIPTION
Allows generating the tabs/pills without needing to manually generate the active class for each `li`.