### PR TITLE
Freeze ALERT_TYPES_MAP to save allocations

### DIFF
--- a/app/helpers/bootstrap_flash_helper.rb
+++ b/app/helpers/bootstrap_flash_helper.rb
@@ -5,7 +5,7 @@ module BootstrapFlashHelper
     error: :danger,
     info: :info,
     warning: :warning
-  }
+  }.freeze
 
   def bootstrap_flash
     safe_join(flash.each_with_object([]) do |(type, message), messages|


### PR DESCRIPTION
Added freeze to the map to save allocations (ref: http://blog.honeybadger.io/when-to-use-freeze-and-frozen-in-ruby/)