### PR TITLE
Treat space-separated class names the same as arrays of class names

### DIFF
--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -17,6 +17,9 @@ module UrlHelper
     html_options[:class] ||= []
     html_options[:class] = [*html_options[:class]]
 
+    # Expand space-separated class strings so that each has its own spot in the class array
+    html_options[:class] = html_options[:class].map { |c| c.split }.flatten
+
     html_options[:class].unshift('btn') unless html_options[:class].include?('btn')
     if html_options[:class].select { |cls| UrlHelper::BUTTON_CLASSES.include?(cls) }.empty?
       html_options[:class] << 'btn-default'

--- a/spec/helpers/button_to_helper_spec.rb
+++ b/spec/helpers/button_to_helper_spec.rb
@@ -15,5 +15,19 @@ describe UrlHelper, :type => :helper do
     it "does not emit a default if a button type is specified" do
       button_to("Test", "/test", class: 'btn-danger').should =~ pattern("Test", "btn-danger")
     end
+
+    it "does not emit a default if a button type is specified in a space-separated class" do
+      button_to("Test", "/test", class: 'xyz btn-primary').should =~ pattern("Test", "xyz btn-primary")
+    end
+
+    context "with arrays of classes" do
+      it "does not emit a default if a button type is specified as one of an array of classes" do
+        button_to("Test", "/test", class: ['xyz', 'btn-primary']).should =~ pattern("Test", "xyz btn-primary")
+      end
+
+      it "does not emit a default if a button type is specified within a space-separated class" do
+        button_to("Test", "/test", class: ['xyz btn-primary']).should =~ pattern("Test", "xyz btn-primary")
+      end
+    end
   end
 end


### PR DESCRIPTION
We generally add multiple space-separated class names inside html_options. This patch fixes the bug that arises when we put btn-primary on a button within a space-separated string of class names.

Before the patch, it adds btn-default, which we do not want. After the patch, it behaves the way we would expect.