### PR TITLE
use `before_action` over deprecated `before_filter` 

### DIFF
--- a/lib/bootstrap-sass-extras/breadcrumbs.rb
+++ b/lib/bootstrap-sass-extras/breadcrumbs.rb
@@ -10,7 +10,7 @@ module BootstrapSassExtras
     module ClassMethods
       def add_breadcrumb(name, url, options = {})
         class_name = self.name
-        before_filter options do |controller|
+        before_action options do |controller|
           if name.is_a?(Symbol)
             name = controller.send :translate_breadcrumb, name, class_name
           end


### PR DESCRIPTION
`DEPRECATION WARNING: before_filter is deprecated and will be removed in Rails 5.1. Use before_action instead.`