### PR TITLE
Add nav_to option to force active state

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ In your views:
     Profile
   <% end %>
   <%= nav_to('Messages', controller: users, action: :messages) %>
+  <%= nav_to('Forced active state', some_path, active: true) %>
 <% end %>
 ```
 

--- a/app/helpers/nav_helper.rb
+++ b/app/helpers/nav_helper.rb
@@ -21,10 +21,17 @@ module NavHelper
   end
 
   def nav_to(name = nil, options = nil, html_options = nil, &block)
-    url_options = block_given? ? name : options
+    if block_given?
+      url_options, html_options = name, options
+    else
+      url_options = options
+    end
+
     url_options ||= {}
 
-    tab_class = current_page?(url_options) ? 'active' : nil
+    active = html_options.try(:delete, :active)
+    active = current_page?(url_options) if active.nil?
+    tab_class = active ? 'active' : nil
 
     content_tag(:li, role: 'presentation', class: tab_class) do
       link_to(name, options, html_options, &block)

--- a/spec/helpers/nav_helper_spec.rb
+++ b/spec/helpers/nav_helper_spec.rb
@@ -52,5 +52,28 @@ describe NavHelper, :type => :helper do
         (pills class: 'nav-stacked').should == html
       end
     end
+
+    context "when nav tab_class given" do
+      let(:html) {
+        <<-TABS.strip_heredoc
+            <ul class="nav nav-tabs">
+              <li role="presentation"><a href="/">Name</a></li>
+              <li role="presentation" class="active"><a href="/profile">Profile</a></li>
+            </ul>
+        TABS
+      }
+
+      it "generates the correct tabs" do
+        (nav do
+          concat "\n  "
+          concat (nav_to 'Name', '/', active: false)
+          concat "\n  "
+          concat (nav_to '/profile', active: true do
+            'Profile'
+          end)
+          concat "\n"
+        end + "\n").should == html
+      end
+    end
   end
 end


### PR DESCRIPTION
With that changes you can override tab/pill state.
Here is an example why it can be helpful:

```ruby
<%= nav do %>
  <%= nav_to('Active tasks', tasks_path(scope: :active) %>
  <%= nav_to('Completed tasks', tasks_path(scope: :completed) %>
<% end %>
```

Tab 'Active tasks' is active only when url query is `?scope=active`. It stops to be active if we have some additional params (i.e. pagination) `?scope=active&page=3`.
It happens because of [ActionView::Helpers::UrlHelper.current_page?](https://apidock.com/rails/ActionView/Helpers/UrlHelper/current_page%3F#docs_body) rails helper behaviour.

With this commit tab/pill state can be forced easily.
```ruby
<%= nav do %>
  <%= nav_to('Active tasks', tasks_path(scope: :active), active: params[:scope] == 'active') %>
  <%= nav_to('Completed tasks', tasks_path(scope: :completed), active: params[:scope] == 'completed') %>
<% end %>
```

