### PR TITLE
Avoid dangerous calling of methods

### DIFF
--- a/lib/bootstrap-sass-extras/breadcrumbs.rb
+++ b/lib/bootstrap-sass-extras/breadcrumbs.rb
@@ -24,7 +24,7 @@ module BootstrapSassExtras
     def add_breadcrumb(name, url = '', options = {})
       @breadcrumbs ||= []
       name = translate_breadcrumb(name, self.class.name) if name.is_a?(Symbol)
-      url = send(url.to_s) if url =~ /_path|_url|@/
+      url = send(url) if url.is_a?(Symbol)
       @breadcrumbs << { name: name, url: url, options: options }
     end
 


### PR DESCRIPTION
First of all, thanks for making this nice little gems. We've been using this for years and it's essential to us.

Recently we observed some missing method exceptions from this gem, and they happen when we pass strings containing `@` to `add_breadcrumb` method calls. (e.g. as URL query parameters)

I'm not sure why there's a such check for `/_path|_url|@/` but I think the case is for Rails path helpers, so it should be reasonable to just detect symbols instead.